### PR TITLE
bump minimatch, successfully run tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "async": "^1.4.2",
     "debug": "^2.2.0",
     "mime": "^1.3.4",
-    "minimatch": "^2.0.10",
+    "minimatch": "^3.0.4",
     "rdf-ext": "^0.3.0",
     "rdf-formats-common": "^0.3.0",
     "string": "^3.3.1"


### PR DESCRIPTION
bump minimatch to avoid

`folder-to-rdf > minimatch@2.0.10: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue`